### PR TITLE
Switching to runit for more robust behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A stack for deploying flask/django python applications via Docker, utilizing gunicorn and nginx.
+A stack for deploying flask/django python applications via Docker, utilizing gunicorn, nginx, and runit.
 
 [Dockerhub](https://hub.docker.com/r/bnbalsamo/flask_stack/)
 

--- a/gunicorn_run
+++ b/gunicorn_run
@@ -1,0 +1,7 @@
+#!/bin/sh
+PID=/var/run/gunicorn.pid
+
+if [ -f $PID ]; then rm $PID; fi
+
+cd /code
+gunicorn $APP_NAME:$APP_CALLABLE -k $GUNICORN_WORKER_TYPE -w $GUNICORN_WORKERS -t $GUNICORN_TIMEOUT -b unix:/tmp/gunicorn.sock --pid=$PID $GUNICORN_CLI_EXTEND

--- a/nginx.template
+++ b/nginx.template
@@ -3,7 +3,7 @@ worker_processes $NGINX_WORKER_PROCESSES;
 user $NGINX_USER $NGINX_GROUP;
 # 'user nobody nobody;' for systems with 'nobody' as a group instead
 pid /tmp/nginx.pid;
-error_log /tmp/nginx.error.log;
+error_log /dev/stderr;
 
 events {
   worker_connections $NGINX_WORKER_CONNECTIONS; # increase if you have lots of clients

--- a/nginx_conf_build.sh
+++ b/nginx_conf_build.sh
@@ -16,9 +16,3 @@ envsubst '$$NGINX_WORKER_PROCESSES \
           $$NGINX_ROOT_EXTEND \
           $$NGINX_UPSTREAM_EXTEND \
           $$NGINX_PROXY_EXTEND' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf
-# Be sure an APP_NAME env var is available
-test -n "$APP_NAME"
-# Fire up gunicorn, bind to a socket, background
-gunicorn $APP_NAME:$APP_CALLABLE -k $GUNICORN_WORKER_TYPE -w $GUNICORN_WORKERS -t $GUNICORN_TIMEOUT -b unix:/tmp/gunicorn.sock $GUNICORN_CLI_EXTEND &
-# Fire up nginx, keep it in the foreground
-nginx -g "daemon off;" $NGINX_CLI_EXTEND

--- a/nginx_run
+++ b/nginx_run
@@ -1,0 +1,2 @@
+#!/bin/sh
+nginx -g "daemon off;" $NGINX_CLI_EXTEND


### PR DESCRIPTION
Adds runit to the container to manage running nginx and gunicorn.

Cleans up some output from the build and moves nginx error logging to stderr in the container so that it can be scooped up by something else more easily.

The nginx conf is now built on container start, so that changes made to env variables at docker run are reflected in behavior.