### PR TITLE
Package installation via apk hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.5-alpine
 # Slot in the stuff we'll need for making the nginx conf
 COPY ./nginx_conf_build.sh /nginx_conf_build.sh
 COPY ./nginx.template /etc/nginx/nginx.template
+COPY ./install_user_specified_packages.sh /install_user_specified_packages.sh
 # And the runit service definitions
 COPY gunicorn_run /etc/sv/gunicorn/run
 COPY nginx_run /etc/sv/nginx/run
@@ -208,6 +209,7 @@ ONBUILD RUN \
         # Pull alpine-sdk in so most stuff _probably_ builds
         # if it requires external libs
         alpine-sdk \
+    && sh /install_user_specified_packages.sh \
     && pip install -r requirements.txt \
     && python /code/setup.py install \
     && rm -rf /var/cache/apk/* \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A stack for deploying flask/django python applications via Docker, utilizing gun
 
 v0.1.1
 
+[Github](https://github.com/bnbalsamo/docker-flask_stack)
 [Dockerhub](https://hub.docker.com/r/bnbalsamo/flask_stack/)
 
 # Usage

--- a/install_user_specified_packages.sh
+++ b/install_user_specified_packages.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -e /code/apk_packages.txt ]; then
+ while IFS='' read line; do
+  apk add --no-cache $line; 
+ done < /code/apk_packages.txt; 
+fi 


### PR DESCRIPTION
Adds a small script to the docker images which reads a file called ```apk_packages.txt``` if it exists in the inheriting Dockerfile's base dir and attempts to install those packages before the python build using apk.

If there is no file named apk_packages.txt nothing occurs.

apk_packages.txt should end with a blank line (aka, EOF shouldn't occur on the same line as a package you want installed, see the third bullet of the accepted answer [here](https://stackoverflow.com/questions/10929453/read-a-file-line-by-line-assigning-the-value-to-a-variable))