### PR TITLE
Making both requirements.txt and apk_packages.txt optional.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.5-alpine
 # Slot in the stuff we'll need for making the nginx conf
 COPY ./nginx_conf_build.sh /nginx_conf_build.sh
 COPY ./nginx.template /etc/nginx/nginx.template
-COPY ./install_user_specified_packages.sh /install_user_specified_packages.sh
 # And the runit service definitions
 COPY gunicorn_run /etc/sv/gunicorn/run
 COPY nginx_run /etc/sv/nginx/run
@@ -209,8 +208,9 @@ ONBUILD RUN \
         # Pull alpine-sdk in so most stuff _probably_ builds
         # if it requires external libs
         alpine-sdk \
-    && sh /install_user_specified_packages.sh \
-    && pip install -r requirements.txt \
+
+    && if [ -e /code/apk_packages.txt ]; then while IFS='' read line; do apk add --no-cache $line; done < /code/apk_packages.txt; fi \
+    && if [ -e requirements.txt ]; then pip install -r requirements.txt; fi \
     && python /code/setup.py install \
     && rm -rf /var/cache/apk/* \
     && apk del .build-deps

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ v0.2.0
 # Usage
 
 - Inherit from this image in your own project's Dockerfile.
-- Be sure to include a requirements.txt in the root directory of your project
 - Be sure to include a setup.py in the root directory of your project
 - Set any project specific environmental variables in your projects Dockerfile
 - Set the environmental variable APP_NAME to the module name which contains your wsgi callable
-- Set the environmental variable APP_CALLABLE if the callable is not named "app"
+- Optionally, include a file named apk_packages.txt in your project directory
+    - This should be a file with one alpine package name per line
+    - These will be installed via ```apk add --no-cache $x``` _before_ your python package is built
+- Optionally, include a requirements.txt in the root directory of your project
+    - Requirements in requirements.txt will be installed via ```pip -r requirements.txt``` _before_ setup.py is invoked
+- Optionally, set the environmental variable APP_CALLABLE if the callable is not named "app"
 - Build your project
 - Run a container
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A stack for deploying flask/django python applications via Docker, utilizing gun
 v0.2.0
 
 [Github](https://github.com/bnbalsamo/docker-flask_stack)
+
 [Dockerhub](https://hub.docker.com/r/bnbalsamo/flask_stack/)
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ v0.2.0
 - Set any project specific environmental variables in your projects Dockerfile
 - Set the environmental variable APP_NAME to the module name which contains your wsgi callable
 - Optionally, include a file named apk_packages.txt in your project directory
-    - This should be a file with one alpine package name per line
+    - This should be a file with one alpine package name per line, **ending with a blank line**
     - These will be installed via ```apk add --no-cache $x``` _before_ your python package is built
 - Optionally, include a requirements.txt in the root directory of your project
     - Requirements in requirements.txt will be installed via ```pip -r requirements.txt``` _before_ setup.py is invoked

--- a/install_user_specified_packages.sh
+++ b/install_user_specified_packages.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-if [ -e /code/apk_packages.txt ]; then
- while IFS='' read line; do
-  apk add --no-cache $line; 
- done < /code/apk_packages.txt; 
-fi 


### PR DESCRIPTION
 Removed the additional script file (for apk add's) and instead just included the script as a one-liner in the Dockerfile.

Should be entirely backwards compatible.