### PR TITLE
fixes handling of dependency_links specified dependencies in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,8 +210,8 @@ ONBUILD RUN \
         alpine-sdk \
 
     && if [ -e /code/apk_packages.txt ]; then while IFS='' read line; do apk add --no-cache $line; done < /code/apk_packages.txt; fi \
-    && if [ -e requirements.txt ]; then pip install -r requirements.txt; fi \
     && python /code/setup.py install \
+    && if [ -e requirements.txt ]; then pip install -r requirements.txt; fi \
     && rm -rf /var/cache/apk/* \
     && apk del .build-deps
 # We should be good to go, fire it up.


### PR DESCRIPTION
runs ```python setup.py install``` before ```pip install -r requirements.txt``` so that if a requirement from a dependency_links source (aka, github) is specified it doesn't break the build