### PR TITLE
reverting setup.py --> requirements.txt to requirements.txt --> setup.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,8 +210,8 @@ ONBUILD RUN \
         alpine-sdk \
 
     && if [ -e /code/apk_packages.txt ]; then while IFS='' read line; do apk add --no-cache $line; done < /code/apk_packages.txt; fi \
-    && python /code/setup.py install \
     && if [ -e /code/requirements.txt ]; then pip install -r /code/requirements.txt; fi \
+    && python /code/setup.py install \
     && rm -rf /var/cache/apk/* \
     && apk del .build-deps
 # We should be good to go, fire it up.


### PR DESCRIPTION
After doing some reading re: requirements.txt vs setup.py I'm opting to revert the change made in a831ec797b486f150/#13. Requirements.txt will again be read first. I made the decision to run setup.py first in order to handle the dependency_links array intelligently when hooking setup.py via a -e . line in requirements.txt. I think dependency_links in this case does break the 'abstract dependency' thinking, and there are cleaner ways to handle dependency resolution via packaging differently, uploading to pypi, manually installing unpackaged dependencies, running pip and setup.py separately, etc.

**Note**: This means _if_ you use a -e . line in your requirements.txt you must duplicate installs of dependencies from github in requirements.txt via the pip machinery, so they already exist when setup.py is run.

I think this makes sense, as explicitly providing a location to install from can be thought of as similar to pinning a version in that it is making an "abstract" requirement concrete. See "A Setup Tools Misfeature" [here](https://caremad.io/posts/2013/07/setup-vs-requirement/) as well as the idea of abstract/concrete dependency declaration [here](https://packaging.python.org/discussions/install-requires-vs-requirements/)